### PR TITLE
worker: add resource-enrich and resource-ingest to K8s job types

### DIFF
--- a/k8s/apps/longterm-wiki-worker/values.yaml
+++ b/k8s/apps/longterm-wiki-worker/values.yaml
@@ -13,7 +13,7 @@ command:
   - crux/worker/run.ts
   - --poll
   - --poll-interval=5000
-  - --types=claim-verification,citation-verify,resource-verify,ping
+  - --types=claim-verification,citation-verify,resource-verify,resource-enrich,resource-ingest,ping
   - --concurrency=5
   - --verbose
 


### PR DESCRIPTION
## Summary

- Add `resource-enrich` and `resource-ingest` to the K8s worker's `--types` flag
- These handlers only need the wiki-server API + Anthropic SDK (both in the Docker image already)
- Moves processing from GitHub Actions (1 job / 30-min cron) to K8s (3 replicas × concurrency 5, polling every 5s)

## Context

There are **7,958 pending `resource-enrich` jobs** in the queue. The GHA worker processes ~14/day (most of which are skipped). At current rate, clearing the backlog would take ~568 days.

The K8s worker is already running and handling `claim-verification`, `citation-verify`, `resource-verify`, and `ping`. Adding these two types requires zero Docker image changes — the handlers import only from `crux/` and make API calls.

## Risk

Low. Both handlers have skip guards (already-enriched resources are skipped instantly). The `resource-enrich` handler calls Claude Sonnet, so API costs will increase while the backlog drains (~$0.01/job × ~8K jobs ≈ $80 total).

If costs spike unexpectedly, scale down: `kubectl scale deployment longterm-wiki-worker --replicas=1 -n longtermwiki`

## After merge

ArgoCD will auto-sync. Monitor with:
```bash
kubectl logs -l app=longterm-wiki-worker -n longtermwiki --tail=50 -f
WIKI_SERVER_ENV=prod pnpm crux sys jobs stats
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)