### PR TITLE
feat(secrets): dual-key ANTHROPIC_BILLING_KEY for longterm-wiki QUA-612 cutover

### DIFF
--- a/terraform/stacks/longtermwiki/secrets.tf
+++ b/terraform/stacks/longtermwiki/secrets.tf
@@ -61,6 +61,11 @@ resource "kubernetes_secret" "discord_bot_env" {
   }
 
   data = {
+    # QUA-612: dual-keyed. ANTHROPIC_BILLING_KEY is the post-rename name the
+    # app code reads. ANTHROPIC_API_KEY is kept for one transition release so
+    # the cutover is zero-downtime — remove in a follow-up once every
+    # deployed image reads BILLING.
+    ANTHROPIC_BILLING_KEY      = data.onepassword_item.anthropic_api_key.password
     ANTHROPIC_API_KEY          = data.onepassword_item.anthropic_api_key.password
     CLAUDE_CODE_OAUTH_TOKEN    = data.onepassword_item.claude_code_oauth_token.password
     DISCORD_TOKEN              = data.onepassword_item.discord_token.password
@@ -80,6 +85,9 @@ resource "kubernetes_secret" "groundskeeper_env" {
   }
 
   data = {
+    # QUA-612: dual-keyed — see discord_bot_env comment above. Remove
+    # ANTHROPIC_API_KEY in a follow-up once every deployed image reads BILLING.
+    ANTHROPIC_BILLING_KEY  = data.onepassword_item.anthropic_api_key.password
     ANTHROPIC_API_KEY      = data.onepassword_item.anthropic_api_key.password
     GITHUB_APP_ID          = "856482"
     GITHUB_INSTALLATION_ID = "48463969"
@@ -105,6 +113,9 @@ resource "kubernetes_secret" "worker_env" {
   data = {
     LONGTERMWIKI_SERVER_URL    = "http://longterm-wiki-server-wiki-server.longtermwiki.svc.cluster.local"
     LONGTERMWIKI_SERVER_API_KEY = data.onepassword_item.server_api_key.password
+    # QUA-612: dual-keyed — see discord_bot_env comment above. Remove
+    # ANTHROPIC_API_KEY in a follow-up once every deployed image reads BILLING.
+    ANTHROPIC_BILLING_KEY      = data.onepassword_item.anthropic_api_key.password
     ANTHROPIC_API_KEY          = data.onepassword_item.anthropic_api_key.password
   }
 


### PR DESCRIPTION
## Summary

Adds `ANTHROPIC_BILLING_KEY` alongside the existing `ANTHROPIC_API_KEY` in the three k8s secrets that carry the Anthropic billing credential:

- `longtermwiki-discord-bot-env`
- `longtermwiki-groundskeeper-env`
- `longtermwiki-worker-env`

Both keys point at the same 1Password item (`Longtermwiki ANTHROPIC_API_KEY`, vault label unchanged).

## Why

Wiki repo PR [quantified-uncertainty/longterm-wiki#4504](https://github.com/quantified-uncertainty/longterm-wiki/pull/4504) (QUA-612) renames `ANTHROPIC_API_KEY` → `ANTHROPIC_BILLING_KEY` throughout the wiki code so the `claude` CLI can't silently pick up the billing key from `ANTHROPIC_API_KEY` and bypass OAuth. That PR is queued in today's release PR [quantified-uncertainty/longterm-wiki#4506](https://github.com/quantified-uncertainty/longterm-wiki/pull/4506).

Per #4504's body, the rename is a **hard cutover** — if the wiki PR deploys before the pods see `ANTHROPIC_BILLING_KEY` in their env, discord-bot / groundskeeper / worker pods lose the billing key and @mention queries, scheduled jobs, and LLM job handlers fail loudly.

Dual-keying (both names present) eliminates both edges of the cutover race:

| | Ops applies first | Wiki deploys first |
|---|---|---|
| **Straight rename** | Old code in-flight breaks (still reads API_KEY) | New code breaks (no BILLING in env) |
| **Dual-key (this PR)** | No impact — both names present, old code finds API_KEY | No impact — both names present, new code finds BILLING |

## Cutover sequence

1. **This PR** merges and applies via terraform → both key names present in k8s.
2. Wiki PR #4506 merges → deployed images read `ANTHROPIC_BILLING_KEY`. The unused `ANTHROPIC_API_KEY` remains in the pod env but does nothing.
3. `lw/.env.base` at the workspace root gets renamed in lockstep with the wiki PR — managed outside this repo.
4. **Follow-up ops PR** (next release cycle) removes the `ANTHROPIC_API_KEY` entry from all three secrets, leaving `ANTHROPIC_BILLING_KEY` as the sole key.

## Rollback

Safe. Reverting this PR just removes `ANTHROPIC_BILLING_KEY` from the three secrets; `ANTHROPIC_API_KEY` remains untouched, so any code still reading the old name keeps working. The wiki PR (which reads the new name) would break if we revert — but that's the purpose of the cutover ordering.

## Test plan

- [x] `terraform fmt` clean — only whitespace + added keys
- [x] `terraform validate` clean (would be nice to confirm in CI)
- [ ] Post-apply: verify the three secrets have both keys — `kubectl get secret longtermwiki-discord-bot-env -n longtermwiki -o json | jq '.data | keys'`
- [ ] Post-apply: verify pods see both env vars — `kubectl exec -n longtermwiki deploy/longterm-wiki-discord-bot -- env | grep ANTHROPIC_`
- [ ] After wiki #4506 rolls out: confirm discord-bot @mention, groundskeeper scheduled run, and worker `resource-ingest` job all succeed (they implicitly verify BILLING reaches the pods)