### PR TITLE
fix(worker): use renamed claim-sourcing job type in --types arg (QUA-1039)

### DIFF
--- a/k8s/apps/longterm-wiki-worker/values.yaml
+++ b/k8s/apps/longterm-wiki-worker/values.yaml
@@ -13,7 +13,7 @@ command:
   - crux/worker/run.ts
   - --poll
   - --poll-interval=5000
-  - --types=claim-verification,citation-verify,resource-verify,resource-enrich,resource-ingest,ping
+  - --types=claim-sourcing,citation-verify,resource-verify,resource-enrich,resource-ingest,ping
   - --concurrency=5
   - --verbose
 


### PR DESCRIPTION
## Summary

- Workers were polling for `claim-verification` — the old name — so `claim-sourcing` jobs piled up unconsumed (12 stuck for 2.6h+ in prod).
- One-line fix to `--types` arg in helm values; ArgoCD rolls workers on merge and the queue drains on next poll.

## Context

The handler was renamed `claim-verification` → `claim-sourcing` in QUA-237. QUA-699 patched the handler registry and added a regression test, but the worker's k8s `--types` arg was missed. Linear: [QUA-1039](https://linear.app/quantifieduncertainty/issue/QUA-1039/worker-types-arg-uses-old-name-claim-verification-claim-sourcing-jobs).

## Test plan

- [ ] Merge → confirm ArgoCD rolls `longterm-wiki-worker` pods
- [ ] `kubectl logs -n longtermwiki -l app=longterm-wiki-worker-worker --tail=20` shows `claim-sourcing` in the claim type list
- [ ] `wiki-server health` reports `pendingJobs` dropping below 12 within ~1 min
- [ ] No stuck `claim-sourcing` jobs >5 min after rollout

## Follow-up (separate PR)

Add a guard so this can't recur — assert worker `--types` ⊆ `getRegisteredTypes()` (would have caught both this and the original QUA-699 miss).

🤖 Generated with [Claude Code](https://claude.com/claude-code)