### PR TITLE
add backfill-sources to worker --types

### DIFF
--- a/k8s/apps/longterm-wiki-worker/values.yaml
+++ b/k8s/apps/longterm-wiki-worker/values.yaml
@@ -13,7 +13,7 @@ command:
   - crux/worker/run.ts
   - --poll
   - --poll-interval=5000
-  - --types=claim-sourcing,citation-verify,resource-verify,resource-enrich,resource-ingest,ping
+  - --types=claim-sourcing,citation-verify,resource-verify,resource-enrich,resource-ingest,ping,backfill-sources
   - --concurrency=5
   - --verbose
 


### PR DESCRIPTION
## Summary
- The wiki repo added a `backfill-sources` job handler and a daily `backfill-sources-enqueue` groundskeeper task, but the worker's `--types` argument didn't include it, so any enqueued job would never be claimed.

## Test plan
- [ ] After merge + redeploy, manually enqueue a `backfill-sources` job and confirm a worker pod picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)