### PR TITLE
feat(longtermwiki): add OPENROUTER_API_KEY + EXA_API_KEY to worker secret

### DIFF
--- a/terraform/stacks/longtermwiki/secrets.tf
+++ b/terraform/stacks/longtermwiki/secrets.tf
@@ -29,6 +29,22 @@ data "onepassword_item" "claude_code_oauth_token" {
   title = "Longtermwiki CLAUDE_CODE_SUBSCRIPTION_OATH_TOKEN"
 }
 
+# Search-provider keys for the backfill-sources job (QUA-933). The worker's
+# URL-suggestion search uses two providers: "perplexity" (routed through
+# OpenRouter, so it reads OPENROUTER_API_KEY) and "exa" (EXA_API_KEY). Without
+# these the worker silently skips both providers and every backfill run finds
+# 0 sources at $0 cost. OPENROUTER_API_KEY also powers the OpenRouter
+# extraction/entailment/ranking models in the backfill pipeline.
+data "onepassword_item" "openrouter_api_key" {
+  vault = module.providers.op_vault
+  title = "Longtermwiki OPENROUTER_API_KEY"
+}
+
+data "onepassword_item" "exa_api_key" {
+  vault = module.providers.op_vault
+  title = "Longtermwiki EXA_API_KEY"
+}
+
 # Create namespace
 resource "kubernetes_namespace" "longtermwiki" {
   metadata {
@@ -117,6 +133,10 @@ resource "kubernetes_secret" "worker_env" {
     # ANTHROPIC_API_KEY in a follow-up once every deployed image reads BILLING.
     ANTHROPIC_BILLING_KEY      = data.onepassword_item.anthropic_api_key.password
     ANTHROPIC_API_KEY          = data.onepassword_item.anthropic_api_key.password
+    # Search + LLM providers for backfill-sources (QUA-933). Without these the
+    # job runs green but finds 0 sources.
+    OPENROUTER_API_KEY         = data.onepassword_item.openrouter_api_key.password
+    EXA_API_KEY                = data.onepassword_item.exa_api_key.password
   }
 
   depends_on = [kubernetes_namespace.longtermwiki]


### PR DESCRIPTION
## Problem

The `backfill-sources` cron (QUA-933) runs nightly in the worker container and **completes green but finds 0 sources at $0 cost** every run (verified 05-19 → 05-24 in the prod `jobs` table, plus a manual run #73772).

Root cause: the `longtermwiki-worker-env` secret only carries the Anthropic + server keys. The URL-suggestion search (`crux/lib/sourcing/suggest-urls.ts`) uses two providers, both **default-on and silently skipped when their key is missing**:

| Provider | Env var read |
|---|---|
| `perplexity` | `OPENROUTER_API_KEY` (routed via OpenRouter) |
| `exa` | `EXA_API_KEY` |

With neither key present, both providers return `[]` → 0 candidates → nothing for the downstream Haiku/Sonnet stages to score (hence $0 across all stages, not just search).

`OPENROUTER_API_KEY` also powers the OpenRouter extraction/entailment/ranking models in the backfill pipeline.

## Change

Adds `OPENROUTER_API_KEY` and `EXA_API_KEY` to `longtermwiki-worker-env`, backed by 1Password (same pattern as the existing keys).

## ⚠️ Prerequisite before apply

These 1Password items must exist in `op_vault`, or the plan fails on the data lookups:
- `Longtermwiki OPENROUTER_API_KEY`
- `Longtermwiki EXA_API_KEY`

## Verify after apply

- Worker pods pick up the new env (secret change → restart the deployment if not automatic).
- Enqueue a small backfill job: `crux jobs create backfill-sources --params '{"limit":3,"maxCost":0.5}'`
- Expect `Sources found > 0` and non-zero cost in the job result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
