### PR TITLE
fix(worker): SCRY key + .credential fix + raise memory/heap for backfill

### DIFF
--- a/k8s/apps/longterm-wiki-worker/templates/deployment.yaml
+++ b/k8s/apps/longterm-wiki-worker/templates/deployment.yaml
@@ -27,6 +27,12 @@ spec:
               value: {{ .Values.healthPort | quote }}
             - name: NODE_ENV
               value: production
+            # Raise the V8 heap cap. The backfill-sources child (spawned via
+            # node) inherits this env; on large batches it otherwise hits the
+            # ~512MB default heap limit and aborts with "JavaScript heap out of
+            # memory". Keep below resources.limits.memory to leave off-heap room.
+            - name: NODE_OPTIONS
+              value: {{ .Values.nodeOptions | quote }}
           ports:
             - name: health
               containerPort: {{ .Values.healthPort }}

--- a/k8s/apps/longterm-wiki-worker/values.yaml
+++ b/k8s/apps/longterm-wiki-worker/values.yaml
@@ -19,10 +19,16 @@ command:
 
 healthPort: 3101
 
+# Raise V8 heap to 2GB. The default (~512MB) OOMs the backfill-sources child on
+# large batches ("JavaScript heap out of memory"). The child inherits NODE_OPTIONS
+# from the worker container. Kept below resources.limits.memory so off-heap
+# allocations + buffers still fit. Worker nodes are 4GB, so we don't go higher.
+nodeOptions: "--max-old-space-size=2048"
+
 resources:
   requests:
-    memory: "256Mi"
+    memory: "512Mi"
     cpu: "250m"
   limits:
-    memory: "1Gi"
+    memory: "2560Mi"
     cpu: "1000m"

--- a/terraform/stacks/longtermwiki/secrets.tf
+++ b/terraform/stacks/longtermwiki/secrets.tf
@@ -30,10 +30,11 @@ data "onepassword_item" "claude_code_oauth_token" {
 }
 
 # Search-provider keys for the backfill-sources job (QUA-933). The worker's
-# URL-suggestion search uses two providers: "perplexity" (routed through
-# OpenRouter, so it reads OPENROUTER_API_KEY) and "exa" (EXA_API_KEY). Without
-# these the worker silently skips both providers and every backfill run finds
-# 0 sources at $0 cost. OPENROUTER_API_KEY also powers the OpenRouter
+# URL-suggestion search uses three providers: "perplexity" (routed through
+# OpenRouter, so it reads OPENROUTER_API_KEY), "exa" (EXA_API_KEY), and "scry"
+# (SCRY_API_KEY — the EA Forum / LessWrong search). Without a key each provider
+# is skipped or falls back to a public key; the SCRY public fallback now returns
+# 401 and aborts the whole run. OPENROUTER_API_KEY also powers the OpenRouter
 # extraction/entailment/ranking models in the backfill pipeline.
 data "onepassword_item" "openrouter_api_key" {
   vault = module.providers.op_vault
@@ -43,6 +44,13 @@ data "onepassword_item" "openrouter_api_key" {
 data "onepassword_item" "exa_api_key" {
   vault = module.providers.op_vault
   title = "Longtermwiki EXA_API_KEY"
+}
+
+# SCRY's personal key lives in the "EXOPRIORS_API_KEY" 1Password item (Scry is
+# the Exopriors search service).
+data "onepassword_item" "scry_api_key" {
+  vault = module.providers.op_vault
+  title = "Longtermwiki EXOPRIORS_API_KEY"
 }
 
 # Create namespace
@@ -136,7 +144,10 @@ resource "kubernetes_secret" "worker_env" {
     # Search + LLM providers for backfill-sources (QUA-933). Without these the
     # job runs green but finds 0 sources.
     OPENROUTER_API_KEY         = data.onepassword_item.openrouter_api_key.password
-    EXA_API_KEY                = data.onepassword_item.exa_api_key.password
+    # EXA + EXOPRIORS are API_CREDENTIAL items — secret lives in `.credential`,
+    # not `.password` (which is empty and would be dropped from the secret).
+    EXA_API_KEY                = data.onepassword_item.exa_api_key.credential
+    SCRY_API_KEY               = data.onepassword_item.scry_api_key.credential
   }
 
   depends_on = [kubernetes_namespace.longtermwiki]


### PR DESCRIPTION
Follow-up to #63 (which merged but referenced the search-key items via `.password`, leaving EXA empty). Two fixes to make the `backfill-sources` worker actually function.

## 1. Search keys (already applied to prod)

- The `Longtermwiki EXA_API_KEY` and `Longtermwiki EXOPRIORS_API_KEY` 1Password items are **API_CREDENTIAL** category — their secret lives in `.credential`, not `.password`. #63 used `.password`, which resolved to empty and got dropped, so EXA never reached prod.
- Switch EXA + SCRY to `.credential`, and add `SCRY_API_KEY` (sourced from the EXOPRIORS item — Scry is the Exopriors search service).
- Applied via `terraform apply -target=kubernetes_secret.worker_env`; verified the live secret now has `OPENROUTER_API_KEY`, `EXA_API_KEY`, `SCRY_API_KEY`.

## 2. Worker memory + node heap (needs deploy)

Large batches crash the spawned `crux.mjs` child with `FATAL ERROR: Reached heap limit - JavaScript heap out of memory` (V8's ~512MB default), failing the job after retries.

- `NODE_OPTIONS=--max-old-space-size=2048` (the child inherits it).
- Container memory: requests 256Mi → 512Mi, limit 1Gi → 2560Mi (off-heap room above the 2GB heap; within the 4GB worker-node budget).

## After merge

- argocd syncs the worker chart → pods restart with the new memory limit + heap.
- Re-run `backfill-sources --limit=50 --max-cost=10`; confirm no OOM and it completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
