### PR TITLE
worker: bump memory request 512Mi → 1536Mi

### DIFF
--- a/k8s/apps/longterm-wiki-worker/values.yaml
+++ b/k8s/apps/longterm-wiki-worker/values.yaml
@@ -27,7 +27,7 @@ nodeOptions: "--max-old-space-size=2048"
 
 resources:
   requests:
-    memory: "512Mi"
+    memory: "1536Mi"
     cpu: "250m"
   limits:
     memory: "2560Mi"


### PR DESCRIPTION
Raises the longterm-wiki-worker memory **request** from 512Mi to 1536Mi.

**Why:** the scheduler places pods and the kubelet evicts pods by memory *request*, not limit. The `backfill-sources` worker peaks near 1GB but only requested 512Mi, so under node memory pressure the kubelet picked it as a top eviction candidate and killed it mid-job. Reserving 1536Mi makes it a poor eviction target and ensures the scheduler reserves real space for it.

Limit stays at 2560Mi; only the request changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)